### PR TITLE
Add ports for eXist-db and Saxon

### DIFF
--- a/compile.xqm
+++ b/compile.xqm
@@ -65,7 +65,7 @@ declare function compile:schema($schema as element(sch:schema), $phase as xs:str
     <svrl:schematron-output>
       {output:schema-title($schema/sch:title)}
       {$schema/@schemaVersion}
-      {if($active-phase) then attribute{'phase'}{$active-phase/@id}}
+      {if($active-phase) then attribute{'phase'}{$active-phase/@id} else ()}
       {output:namespace-decls-as-svrl($schema/sch:ns)}
     {'{', string-join(
       for $pattern in $active-patterns 

--- a/context.xqm
+++ b/context.xqm
@@ -4,6 +4,8 @@
 
 module namespace c = 'http://www.andrewsales.com/ns/xqs-context';
 
+import module namespace port = 'http://www.andrewsales.com/ns/port'
+  at 'port.xqm';
 import module namespace utils = 'http://www.andrewsales.com/ns/xqs-utils'
   at 'utils.xqm';    
 
@@ -248,10 +250,10 @@ as map(*)
 {
   (: let $_ := trace('>>>QUERY='||$query) :)
   let $value as item()* := if($variable/@value) 
-    then xquery:eval(
+    then port:eval(
       $query => utils:escape(),
-      map:merge(($bindings, map{'':$instance})),
-      map{'pass':'true'}
+      $bindings,
+      $instance
     )
     else $variable/*
   let $bindings := map:merge(
@@ -283,10 +285,10 @@ as map(*)
 {
   if($documents) 
   then 
-    let $uris := xquery:eval(
+    let $uris := port:eval(
       utils:make-query-prolog($context) || $documents => utils:escape(),
-      map:merge(($context?globals, map{'':$context?instance})),
-      map{'pass':'true'}       (:report exception details:)
+      $context?globals,
+      $context?instance
     )
     return map:put(
       $context, 

--- a/context.xqm
+++ b/context.xqm
@@ -4,7 +4,7 @@
 
 module namespace c = 'http://www.andrewsales.com/ns/xqs-context';
 
-import module namespace util = 'http://www.andrewsales.com/ns/xqs-utils' 
+import module namespace utils = 'http://www.andrewsales.com/ns/xqs-utils'
   at 'utils.xqm';    
 
 declare namespace sch = "http://purl.oclc.org/dsdl/schematron";
@@ -31,8 +31,8 @@ as map(*)
   let $active-patterns as element(sch:pattern)+ := c:get-active-patterns($schema, $active-phase)
   let $namespaces as xs:string? := c:make-ns-decls($schema/sch:ns)
   let $globals as element(sch:let)* := ($schema, $active-phase)/sch:let
-  let $_ := (util:check-duplicate-variable-names($schema/sch:let), 
-  util:check-duplicate-variable-names($active-phase/sch:let))
+  let $_ := (utils:check-duplicate-variable-names($schema/sch:let),
+  utils:check-duplicate-variable-names($active-phase/sch:let))
   let $globals as map(*) := if($globals) 
     then c:evaluate-global-variables(
       $globals, 
@@ -155,8 +155,8 @@ as map(*)
   else 
     let $var := head($variables)
     let $prolog := $namespaces || 
-      util:global-variable-external-decls($bindings) || 
-      util:global-variable-decls($var)
+      utils:global-variable-external-decls($bindings) ||
+      utils:global-variable-decls($var)
     
     (: let $_ := trace('[1]$prolog='||serialize($prolog)) :)
     (: let $_ := trace('[2]$bindings='||serialize($bindings, map{'method':'adaptive'})) :)
@@ -204,7 +204,7 @@ as map(*)
   else 
     let $var := head($variables)
     let $prolog := $namespaces || 
-      util:global-variable-external-decls($bindings)
+      utils:global-variable-external-decls($bindings)
     
     (: let $_ := trace('[1]$prolog='||serialize($prolog)) :)
     (: let $_ := trace('[2]$bindings='||serialize($bindings, map{'method':'adaptive'})) :)
@@ -213,7 +213,7 @@ as map(*)
     let $binding := c:evaluate-global-variable(
       $var,
       $instance,
-      $prolog ||  util:local-variable-decls($var) || ' return $' || $var/@name,
+      $prolog ||  utils:local-variable-decls($var) || ' return $' || $var/@name,
       $ns-elems,
       $bindings
     )    
@@ -249,14 +249,14 @@ as map(*)
   (: let $_ := trace('>>>QUERY='||$query) :)
   let $value as item()* := if($variable/@value) 
     then xquery:eval(
-      $query => util:escape(), 
+      $query => utils:escape(),
       map:merge(($bindings, map{'':$instance})),
       map{'pass':'true'}
     )
     else $variable/*
   let $bindings := map:merge(
     (
-      map{util:variable-name-to-QName($variable/@name, $ns-elems):$value},
+      map{utils:variable-name-to-QName($variable/@name, $ns-elems):$value},
       $bindings
     )
   )
@@ -284,9 +284,9 @@ as map(*)
   if($documents) 
   then 
     let $uris := xquery:eval(
-      util:make-query-prolog($context) || $documents => util:escape(),
+      utils:make-query-prolog($context) || $documents => utils:escape(),
       map:merge(($context?globals, map{'':$context?instance})),
-      map{'pass':'true'}	(:report exception details:)
+      map{'pass':'true'}       (:report exception details:)
     )
     return map:put(
       $context, 

--- a/evaluate.xqm
+++ b/evaluate.xqm
@@ -8,7 +8,7 @@ import module namespace context = 'http://www.andrewsales.com/ns/xqs-context' at
   'context.xqm';
 import module namespace output = 'http://www.andrewsales.com/ns/xqs-output' at
   'svrl.xqm';  
-import module namespace util = 'http://www.andrewsales.com/ns/xqs-utils' at
+import module namespace utils = 'http://www.andrewsales.com/ns/xqs-utils' at
   'utils.xqm';
 
 declare namespace sch = "http://purl.oclc.org/dsdl/schematron";
@@ -46,7 +46,7 @@ declare function eval:pattern(
   $context as map(*)
 )
 {
-  let $_ := util:check-duplicate-variable-names($pattern/sch:let)
+  let $_ := utils:check-duplicate-variable-names($pattern/sch:let)
   (:evaluate pattern variables against global context:)
   let $globals as map(*) := context:evaluate-pattern-variables(
         $pattern/sch:let,
@@ -74,7 +74,7 @@ declare function eval:pattern(
     </svrl:active-pattern>, 
     $context?instance ! eval:rules(
       $pattern/sch:rule, 
-      util:make-query-prolog($context), 
+      utils:make-query-prolog($context),
       map:put($context, 'instance', .)
     )
   )
@@ -115,17 +115,17 @@ declare function eval:rule(
 )
 as element()*
 {
-  let $_ := util:check-duplicate-variable-names($rule/sch:let)
+  let $_ := utils:check-duplicate-variable-names($rule/sch:let)
   let $query := string-join(
-      ($prolog, util:local-variable-decls($rule/sch:let), 
+      ($prolog, utils:local-variable-decls($rule/sch:let),
       if($rule/sch:let) then 'return ' else '', $rule/@context),
       ' '
     )
   (: let $_ := trace('[2]RULE query='||$query) :)
   let $rule-context := xquery:eval(
-    $query => util:escape(),
+    $query => utils:escape(),
     map:merge((map{'':$context?instance}, $context?globals)),
-    map{'pass':'true'}	(:report exception details:)
+    map{'pass':'true'} (:report exception details:)
   )
   return 
   if($rule-context)
@@ -153,7 +153,7 @@ declare function eval:assertions(
 )
 as element()*
 {
-  let $prolog := $prolog || util:local-variable-decls($rule/sch:let)
+  let $prolog := $prolog || utils:local-variable-decls($rule/sch:let)
   (: let $_ := trace('[3]ASSERTION prolog='||$prolog) :)
   for $context in $rule-context
     let $prolog := $prolog || (if($rule/sch:let) then ' return ' else '')
@@ -182,7 +182,7 @@ declare function eval:assertion(
 )
 {
   let $result := xquery:eval(
-    $prolog || $assertion/@test => util:escape(),
+    $prolog || $assertion/@test => utils:escape(),
     map:merge((map{'':$rule-context}, $context?globals)),
     map{'pass':'true'}
   )

--- a/evaluate.xqm
+++ b/evaluate.xqm
@@ -31,7 +31,7 @@ declare function eval:schema(
   <svrl:schematron-output>
   {output:schema-title($schema/sch:title)}
   {$schema/@schemaVersion}
-  {if($context?phase) then attribute{'phase'}{$context?phase/@id}}
+  {if($context?phase) then attribute{'phase'}{$context?phase/@id} else ()}
   {output:namespace-decls-as-svrl($schema/sch:ns)}
   {$context?patterns ! eval:pattern(., $context)}
   </svrl:schematron-output>
@@ -70,7 +70,7 @@ declare function eval:pattern(
   return	(:TODO active-pattern/@name:)(
     <svrl:active-pattern>
     {$pattern/(@id, @name, @role), 
-    if($pattern/@documents) then attribute{'documents'}{$context?instance ! base-uri(.)}}
+    if($pattern/@documents) then attribute{'documents'}{$context?instance ! base-uri(.)} else()}
     </svrl:active-pattern>, 
     $context?instance ! eval:rules(
       $pattern/sch:rule, 

--- a/evaluate.xqm
+++ b/evaluate.xqm
@@ -6,6 +6,8 @@ module namespace eval = 'http://www.andrewsales.com/ns/xqs-evaluate';
 
 import module namespace context = 'http://www.andrewsales.com/ns/xqs-context' at
   'context.xqm';
+import module namespace port = 'http://www.andrewsales.com/ns/port' at
+  'port.xqm';
 import module namespace output = 'http://www.andrewsales.com/ns/xqs-output' at
   'svrl.xqm';  
 import module namespace utils = 'http://www.andrewsales.com/ns/xqs-utils' at
@@ -122,10 +124,10 @@ as element()*
       ' '
     )
   (: let $_ := trace('[2]RULE query='||$query) :)
-  let $rule-context := xquery:eval(
+  let $rule-context := port:eval(
     $query => utils:escape(),
-    map:merge((map{'':$context?instance}, $context?globals)),
-    map{'pass':'true'} (:report exception details:)
+    $context?globals,
+    $context?instance
   )
   return 
   if($rule-context)
@@ -181,10 +183,10 @@ declare function eval:assertion(
   $context as map(*)
 )
 {
-  let $result := xquery:eval(
+  let $result := port:eval(
     $prolog || $assertion/@test => utils:escape(),
-    map:merge((map{'':$rule-context}, $context?globals)),
-    map{'pass':'true'}
+    $context?globals,
+    $rule-context
   )
   return
   typeswitch($assertion)

--- a/port.xqm
+++ b/port.xqm
@@ -1,20 +1,30 @@
 module namespace port = 'http://www.andrewsales.com/ns/port';
 
-declare %private variable $port:processor := "existdb"; 
+declare %private variable $port:processor :=
+        if (fn:matches(<a/>/fn:generate-id(), "MD[0-9]+N1"))
+        then
+          "existdb"
+        else if (<a/>/fn:generate-id() eq "d0e0")
+        then
+          "saxon"
+        else
+          "basex"
+        ;
 
 declare %private variable $port:implementation-module-ns :=
-        let $is-existdb := fn:exists(fn:environment-variable("EXIST_HOME"))
-        return
-            switch ($port:processor)
-              case "existdb"
-              return
-                "http://www.andrewsales.com/ns/port/existdb"
-              case "basex"
-              return
-                "http://www.andrewsales.com/ns/port/basex"
-              default
-              return
-                "http://www.andrewsales.com/ns/port/basex"
+          switch ($port:processor)
+            case "existdb"
+            return
+              "http://www.andrewsales.com/ns/port/existdb"
+            case "saxon"
+            return
+              "http://www.andrewsales.com/ns/port/saxon"
+            case "basex"
+            return
+              "http://www.andrewsales.com/ns/port/basex"
+            default
+            return
+              "http://www.andrewsales.com/ns/port/basex"
          ;
 
 declare %private variable $port:implementation-module-location-hint := "port/" || fn:replace($port:implementation-module-ns, ".+/(.+)", "$1") || ".xqm";

--- a/port.xqm
+++ b/port.xqm
@@ -1,0 +1,38 @@
+module namespace port = 'http://www.andrewsales.com/ns/port';
+
+declare %private variable $port:processor := "existdb"; 
+
+declare %private variable $port:implementation-module-ns :=
+        let $is-existdb := fn:exists(fn:environment-variable("EXIST_HOME"))
+        return
+            switch ($port:processor)
+              case "existdb"
+              return
+                "http://www.andrewsales.com/ns/port/existdb"
+              case "basex"
+              return
+                "http://www.andrewsales.com/ns/port/basex"
+              default
+              return
+                "http://www.andrewsales.com/ns/port/basex"
+         ;
+
+declare %private variable $port:implementation-module-location-hint := "port/" || fn:replace($port:implementation-module-ns, ".+/(.+)", "$1") || ".xqm";
+                  
+declare %private variable $port:implementation := fn:load-xquery-module($port:implementation-module-ns, map { "location-hints":  $port:implementation-module-location-hint })?functions;
+
+(:~
+ : Dynamically evaluate a string as an XQuery expression.
+ :
+ : @param query the XQuery string.
+ : @param bindings a map of variable bindings, keys must be of xs:string or xs:QName types.
+ : @param context-item a context item for the XQuery being evaluated.
+ :
+ : @return The results of the execution of the XQuery expression.
+ :)
+declare function port:eval($query as xs:string, $variables as map(*)?, $context-item as item()?) as item()* {
+  	let $eval-functions := $port:implementation(fn:QName($port:implementation-module-ns, "eval"))
+  	let $eval3-function := $eval-functions?3
+  	return
+  		$eval3-function($query, $variables, $context-item)
+};

--- a/port/basex.xqm
+++ b/port/basex.xqm
@@ -1,0 +1,12 @@
+module namespace basex = 'http://www.andrewsales.com/ns/port/basex';
+
+declare namespace map = "http://www.w3.org/2005/xpath-functions/map";
+
+import module namespace xquery = "http://basex.org/modules/xquery";
+
+(:~
+ : Implementation of port.xqm::eval#3.
+ :)
+declare function basex:eval($query as xs:string, $variables as map(*)?, $context-item as item()?) as item()* {
+    xquery:eval($query, map:merge(($variables, $context-item ! map { "" : $context-item })), map { "pass": fn:true() })
+};

--- a/port/existdb.xqm
+++ b/port/existdb.xqm
@@ -1,0 +1,21 @@
+module namespace existdb = 'http://www.andrewsales.com/ns/port/existdb';
+
+declare namespace map = "http://www.w3.org/2005/xpath-functions/map";
+
+import module namespace util = "http://exist-db.org/xquery/util";
+
+(:~
+ : Implementation of port.xqm::eval#3
+ :)
+declare function existdb:eval($query as xs:string, $variables as map(*)?, $context-item as item()?) as item()* {
+    (: TODO(AR) it would be better to pass the variables to util:eval via a different approach, the current approach does not work for function() type parameters (e.g. also Map and Array) :)
+    let $static-context :=
+        <static-context>
+        {
+            map:for-each($variables, function($var-name, $var-value) { <variable name="{$var-name}">{$var-value}</variable> })
+                
+        }
+        </static-context>
+    return
+        util:eval-with-context($query, $static-context, fn:false(), $context-item)
+};

--- a/port/saxon.xqm
+++ b/port/saxon.xqm
@@ -1,0 +1,14 @@
+module namespace sxn = 'http://www.andrewsales.com/ns/port/saxon';
+
+declare namespace map = "http://www.w3.org/2005/xpath-functions/map";
+
+import module namespace saxon = "http://saxon.sf.net/";
+
+(:~
+ : Implementation of port.xqm::eval#3.
+ :)
+declare function sxn:eval($query as xs:string, $variables as map(*)?, $context-item as item()?) as item()* {
+    let $xquery-fn := saxon:xquery($query)
+    return
+      $xquery-fn($context-item, $variables)
+};

--- a/svrl.xqm
+++ b/svrl.xqm
@@ -6,6 +6,9 @@ module namespace output = 'http://www.andrewsales.com/ns/xqs-output';
 declare namespace sch = "http://purl.oclc.org/dsdl/schematron";
 declare namespace svrl = "http://purl.oclc.org/dsdl/svrl";
 
+import module namespace port = 'http://www.andrewsales.com/ns/port'
+  at 'port.xqm';
+
 declare function output:schema-title($title as element(sch:title)?)
 as attribute(title)?
 {
@@ -113,15 +116,17 @@ declare function output:assertion-message-content(
     typeswitch($node)
       case element(sch:name)
         return if($node/@path) 
-          then xquery:eval(
+          then port:eval(
             $prolog || $node/@path, 
-            map:merge((map{'':$rule-context}, $context?globals))
+            $context?globals,
+            $rule-context
           ) 
           else name($rule-context)
       case element(sch:value-of)
-        return xquery:eval(
+        return port:eval(
           $prolog || $node/@select, 
-          map:merge((map{'':$rule-context}, $context?globals))
+          $context?globals,
+          $rule-context
         ) 
         => string()
       case element(sch:emph)

--- a/utils.xqm
+++ b/utils.xqm
@@ -1,6 +1,6 @@
 (:~ Common utility functions. :)
 
-module namespace util = 'http://www.andrewsales.com/ns/xqs-utils';
+module namespace utils = 'http://www.andrewsales.com/ns/xqs-utils';
 
 declare namespace xqs = 'http://www.andrewsales.com/ns/xqs';
 declare namespace sch = "http://purl.oclc.org/dsdl/schematron";
@@ -11,12 +11,12 @@ declare namespace map = "http://www.w3.org/2005/xpath-functions/map";
  : evaluation.
  : @param globals the global variables
  :)
-declare function util:global-variable-decls($globals as element(sch:let)*)
+declare function utils:global-variable-decls($globals as element(sch:let)*)
 as xs:string?
 {
   string-join(
     for $var in $globals
-    return 'declare variable $' || $var/@name || ':=' || util:variable-value($var)  || ';'
+    return 'declare variable $' || $var/@name || ':=' || utils:variable-value($var)  || ';'
   )
 };
 
@@ -24,7 +24,7 @@ as xs:string?
  : Global variables are evaluated and bound as external variables.
  : @param globals the map of evaluated global variables
  :)
-declare function util:global-variable-external-decls($globals as map(*))
+declare function utils:global-variable-external-decls($globals as map(*))
 as xs:string?
 {
   string-join(for $k in map:keys($globals)
@@ -34,12 +34,12 @@ as xs:string?
 (:~ Builds the string of local variable declarations.
  : @param locals the variables to declare
  :)
-declare function util:local-variable-decls($locals as element(sch:let)*)
+declare function utils:local-variable-decls($locals as element(sch:let)*)
 as xs:string
 {
   string-join(
     for $var in $locals
-    return util:declare-variable($var/@name, util:variable-value($var)),
+    return utils:declare-variable($var/@name, utils:variable-value($var)),
     ' '
   )
 };
@@ -50,23 +50,23 @@ as xs:string
  : current context. If no value attribute is specified, the value of the 
  : attribute is the element content of the let element."
  :)
-declare function util:variable-value($var as element(sch:let))
+declare function utils:variable-value($var as element(sch:let))
 as xs:string
 {
   if($var/@as => normalize-space() => matches('^map\([^\)]+\)')) 
   then $var/@value/data()
   else
-  if($var/@value) then $var/@value/data() => util:escape() else serialize($var/*)
+  if($var/@value) then $var/@value/data() => utils:escape() else serialize($var/*)
 };
 
 (:~ Assembles the query prolog of namespace and variable declarations.
  : @param context the validation context
  :)
-declare function util:make-query-prolog($context as map(*))
+declare function utils:make-query-prolog($context as map(*))
 as xs:string?
 {
-  ($context?ns-decls || util:global-variable-external-decls($context?globals))
-  => util:escape() || $context?functions ! string(.)
+  ($context?ns-decls || utils:global-variable-external-decls($context?globals))
+  => utils:escape() || $context?functions ! string(.)
 };
 
 (:~ Creates a QName from a prefixed variable name, looking up any URI from the
@@ -74,7 +74,7 @@ as xs:string?
  : @param name name of the variable
  : @param namespaces namespace declarations
  :)
-declare function util:variable-name-to-QName(
+declare function utils:variable-name-to-QName(
   $name as attribute(name),
   $namespaces as element(sch:ns)*
 )
@@ -90,7 +90,7 @@ as xs:QName
 (:~ Escape ampersands in dynamically-evaluated queries.
  : @param query the string of the query to escape
  :)
-declare function util:escape($query as xs:string)
+declare function utils:escape($query as xs:string)
 as xs:string
 {
   replace($query, '&amp;', '&amp;amp;') 
@@ -98,7 +98,7 @@ as xs:string
   => replace('\}', '&amp;#x7D;') :)
 };
 
-declare function util:declare-variable(
+declare function utils:declare-variable(
   $name as xs:string,
   $value as item()+
 )
@@ -113,7 +113,7 @@ as xs:string
  : scope for any global variable name in the global context and any local 
  : variable name in the local context." 
  :)
-declare function util:check-duplicate-variable-names($decls as element(sch:let)*)
+declare function utils:check-duplicate-variable-names($decls as element(sch:let)*)
 {
   let $names as xs:string* := $decls/@name/string()
   return

--- a/utils.xqm
+++ b/utils.xqm
@@ -122,5 +122,5 @@ declare function util:check-duplicate-variable-names($decls as element(sch:let)*
     xs:QName('xqs:multiply-defined-variable'),
     'duplicate variable name in element ' || local-name(head($decls)/..) || ': '
     || $names[index-of($names, .)[2]]
-  )
+  ) else()
 };

--- a/xqs.xqm
+++ b/xqs.xqm
@@ -6,8 +6,6 @@ import module namespace eval = 'http://www.andrewsales.com/ns/xqs-evaluate' at
   'evaluate.xqm';  
 import module namespace compile = 'http://www.andrewsales.com/ns/xqs-compile' at
   'compile.xqm';    
-import module namespace util = 'http://www.andrewsales.com/ns/xqs-utils' at
-  'utils.xqm';  
 
 declare namespace sch = "http://purl.oclc.org/dsdl/schematron";
 

--- a/xqs.xqm
+++ b/xqs.xqm
@@ -66,10 +66,16 @@ as xs:string
 (:~ Mandate one of the reserved names for the XQuery query language binding. :)
 declare function xqs:check-query-binding($schema as element(sch:schema))
 {
-  if(lower-case($schema/@queryBinding) = ('xquery', 'xquery3', 'xquery31'))
-  then ()
-  else error(
-    xs:QName('xqs:invalid-query-binding'),
-    'query language binding must be XQuery'
-  )
+  let $query-binding := $schema/@queryBinding
+  return
+    if (exists($query-binding))
+    then
+      if(lower-case($query-binding) = ('xquery', 'xquery3', 'xquery31'))
+      then ()
+      else error(
+        xs:QName('xqs:invalid-query-binding'),
+        'query language binding must be XQuery',
+        $schema/@queryBinding
+      )
+    else()
 };


### PR DESCRIPTION
Closes https://github.com/AndrewSales/XQS/issues/8

1. I wasn't quite sure about this one - https://github.com/AndrewSales/XQS/pull/16/commits/1ef3be2aef269dc20fdb718e818bbc312f48a37d
2. I have tested the eXist-db port with just a simple XML Doc and Schematron, and was able to get SVRL using:
    ```xquery
    import module namespace xqs = 'http://www.andrewsales.com/ns/xqs' at 'xmldb:exist:///db/xqs/xqs.xqm';
    xqs:validate(doc('/db/xqs/test/foo.xml'), doc('/db/xqs/test/assertion-message-braces.xml')/*)
    ```
3. I haven't tested the Saxon port.

If you can tell me how to run the BaseX test suite from the command line and determine if it fails or passes (by exit code?), then I could also add GitHub Actions CI to run tests for this against BaseX and eXist-db.