### PR TITLE
[MOD] closes #71

### DIFF
--- a/include-expand.xqm
+++ b/include-expand.xqm
@@ -4,6 +4,9 @@
 
 module namespace ie = 'http://www.andrewsales.com/ns/xqs-include-expand';
 
+import module namespace util = 'http://www.andrewsales.com/ns/xqs-utils' at
+  'utils.xqm';
+
 declare namespace sch = "http://purl.oclc.org/dsdl/schematron";
 
 (:~ Perform inclusion and expansion.
@@ -46,13 +49,13 @@ as element(sch:schema)
   if($copy//sch:include | $copy//sch:extends[@href])
   then ie:process-includes($copy)
   else
-    if($copy/@xml:base)	(:don't replace:)
+    (if($copy/@xml:base)	(:don't replace:)
     then $copy
     else
       copy $copy := $copy
       modify
         insert node attribute{'xml:base'}{$schema/base-uri()} into $copy
-    return $copy
+    return $copy) => util:elements-to-attributes()
 };
 
 (:~ For a given inclusion instruction, retrieve the element to be included,

--- a/test/test-utils.xqm
+++ b/test/test-utils.xqm
@@ -67,3 +67,25 @@ function _:eval()
     <foo/>
   )
 };
+
+(:~ expression-containing attributes convert successfully to lone first child 
+ : elements of that type
+ :)
+declare %unit:test function _:attributes-to-elements()
+{
+  let $result := util:attributes-to-elements(doc('test-cases/attributes-to-elements.sch')/*)
+  return unit:assert-equals(
+    $result, doc('test-cases/elements-to-attributes.sch')/*
+  )
+};
+
+(:~ expression-containing lone first child elements of a given type convert 
+ : successfully to attributes 
+ :)
+declare %unit:test function _:elements-to-attributes()
+{
+  let $result := util:elements-to-attributes(doc('test-cases/elements-to-attributes.sch')/*)
+  return unit:assert-equals(
+    $result, doc('test-cases/attributes-to-elements.sch')/*
+  )
+};

--- a/utils.xqm
+++ b/utils.xqm
@@ -291,3 +291,31 @@ declare function utils:report-edition(
   trace(<sch:schema>{$schema/@schematronEdition}</sch:schema>)    
   else ()
 };
+
+declare function utils:attributes-to-elements(
+  $schema as element(sch:schema)
+)
+as element(sch:schema)
+{
+  copy $copy := $schema
+  modify
+    for $att in ($copy//sch:param/@value | $copy//sch:let/@value | $copy//sch:phase/(@from, @when) | $copy//sch:pattern/@documents | $copy//sch:rule/(@context, @subject, @visit-each) | $copy//(sch:assert | sch:report)/(@test, @subject) | $copy//sch:name/@path | $copy//sch:value-of/@select)
+      return
+      (delete node $att,
+      insert node element{$att/name()}{$att/data()} as first into $att/..)
+  return $copy
+};
+
+declare function utils:elements-to-attributes(
+  $schema as element(sch:schema)
+)
+as element(sch:schema)
+{
+  copy $copy := $schema
+  modify
+    for $elem in ($copy//sch:param/sch:value | $copy//sch:let/sch:value | $copy//sch:phase/(sch:from, sch:when) | $copy//sch:pattern/sch:documents | $copy//sch:rule/(sch:context | sch:subject | sch:visit-each) | $copy//(sch:assert | sch:report)/(sch:test | sch:subject) | $copy//sch:name/sch:path | $copy//sch:value-of/sch:select)
+      return
+    (insert node attribute{$elem/local-name()}{$elem/data()} into $elem/..,
+      delete node $elem)
+  return $copy
+};


### PR DESCRIPTION
This PR enables an input schema to contain, for any attribute whose value is an expression to be evaluated, an element of the same name, in the Schematron namespace.

Any such elements are silently replaced by the conventional Schematron attributes after the schema has been normalized (include and expand processing carried out). Attributes and elements may be mixed and matched in this way, but there is no validation of the input elements, so any duplicates will result in a duplicate attribute error.

**N.B. This is a non-standard, experimental feature.**